### PR TITLE
Add vercel.json to deploy docs/ landing page on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": null,
+  "installCommand": null,
+  "outputDirectory": "docs",
+  "cleanUrls": true
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
-  "buildCommand": null,
-  "installCommand": null,
+  "buildCommand": "",
+  "installCommand": "",
   "outputDirectory": "docs",
   "cleanUrls": true
 }


### PR DESCRIPTION
Adds a `vercel.json` so Vercel serves the existing `docs/` landing page as a static site (no build or install step), enabling the site at https://zimra-fdms.vercel.app.

- `outputDirectory: "docs"` — serves `docs/index.html` and `docs/img/*` directly
- `framework`, `buildCommand`, `installCommand` set to `null` — this is a plain static page, no build needed
- `cleanUrls: true` — serves extensionless URLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsDvkKhkPyMAu7JMcNbXjE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for Vercel hosting.
  * Configured the documentation output directory and cleaner URLs.
  * Preserved default framework, build, and installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->